### PR TITLE
Update to version 2.30.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
           id: build-docker-image-vsearch
           run: |
             ls -la 
-            docker build . -f Dockerfile -t joschlag/vsearch:2.29.1
+            docker build . -f Dockerfile -t joschlag/vsearch:2.30.0
         - name: push the docker image
           id: push-docker-image-vsearch
-          run: docker push ${{secrets.DOCKERHUB_USERNAME}}/vsearch:2.29.1
+          run: docker push ${{secrets.DOCKERHUB_USERNAME}}/vsearch:2.30.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM continuumio/miniconda:4.7.10
+FROM continuumio/miniconda3:25.3.1-1
 
 ENV PATH /opt/conda/bin:$PATH
 
 RUN conda config --append channels bioconda && \
 	conda config --append channels conda-forge && \
 	conda config --append channels anaconda && \
-	conda install -c bioconda vsearch=2.29.1 && \
+	conda install -c bioconda vsearch=2.30.0 && \
 	conda clean -a -y
 
 CMD ["vsearch"]


### PR DESCRIPTION
the image pulls the updated version 2.30.0 of vsearch and uses now an up to date miniconda3 base image(25.3.1-1).